### PR TITLE
[CPP-1122] Remove lib/aws-sdk.rb to avoid namespace collision

### DIFF
--- a/lib/aws-sdk.rb
+++ b/lib/aws-sdk.rb
@@ -1,1 +1,0 @@
-require 'aws-sdk-v1'


### PR DESCRIPTION
We had some failing tests due to a namespace conflict.

```
irb(main):001:0> require 'aws-sdk'
=> true
irb(main):002:0> Aws
NameError: uninitialized constant Aws
```

`aws-sdk` version 2 uses the `Aws` namespace, whereas `aws-sdk-v1` uses the `AWS` namespace. This is so that we can run both versions of the gem at once. There was an issue with `lib/aws-sdk.rb` causing issues with this namespacing, and the solution for this was to remove this file when building the `aws-sdk-v1` gem (see: https://github.com/amazon-archives/aws-sdk-core-ruby/issues/119), as defined in the `aws-sdk-v1.gemspec`. 

However, due to the way we are referencing this gem, via the `git:` tag in our `Gemfile`, Bundler actually doesn't build the gem the usual way via the gemspec file, it basically copies all the files over, and ignores the `files` specification in the `.gemspec` (see: https://github.com/rubygems/rubygems/issues/3194#event-3128994437, and https://bundler.io/man/gemfile.5.html).

The solution here is to remove the `lib/aws-sdk.rb` file. If we had build this gem and installed it, this file would not be present in the actual gem directory, so this should be a safe procedure and not impact the functionality of the `aws-sdk-v1` gem.
